### PR TITLE
Better fly handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.27.0
+version=3.27.1
 plugin-name=VelocityVanish
 
 # Hangar properties
@@ -18,7 +18,7 @@ modrinthMinecraftVersions=1.8.9,\
   1.17,1.17.1,\
   1.18,1.18.1,1.18.2,\
   1.19,1.19.1,1.19.2,1.19.3,1.19.4,\
-  1.20,1.20.1
+  1.20,1.20.1,1.20.2
 modrinthLoaders=paper,purpur,spigot,velocity
 
 # Gradle options

--- a/src/generated/java/ir/syrent/nms/accessors/MobEffectAccessor.java
+++ b/src/generated/java/ir/syrent/nms/accessors/MobEffectAccessor.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Method;
  * <p>
  * This class is a reflection accessor for net.minecraft.world.effect.MobEffect
  *
- * @since 2023-10-01 12:57:10
+ * @since 2023-10-01 13:06:03
  */
 public class MobEffectAccessor {
   /**

--- a/src/generated/java/ir/syrent/nms/accessors/MobEffectInstanceAccessor.java
+++ b/src/generated/java/ir/syrent/nms/accessors/MobEffectInstanceAccessor.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Field;
  * <p>
  * This class is a reflection accessor for net.minecraft.world.effect.MobEffectInstance
  *
- * @since 2023-10-01 12:57:10
+ * @since 2023-10-01 13:06:03
  */
 public class MobEffectInstanceAccessor {
   /**

--- a/src/main/java/ir/syrent/velocityvanish/spigot/VelocityVanishSpigot.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/VelocityVanishSpigot.kt
@@ -6,12 +6,9 @@ import com.comphenix.protocol.events.ListenerPriority
 import com.comphenix.protocol.events.PacketAdapter
 import com.comphenix.protocol.events.PacketEvent
 import com.comphenix.protocol.wrappers.WrappedGameProfile
-import com.cryptomorin.xseries.ReflectionUtils
 import com.google.gson.JsonObject
 import com.jeff_media.updatechecker.UpdateCheckSource
 import com.jeff_media.updatechecker.UpdateChecker
-import com.jeff_media.updatechecker.UserAgentBuilder
-import io.netty.util.internal.ReflectionUtil
 import io.papermc.lib.PaperLib
 import ir.syrent.velocityvanish.spigot.command.VanishCommand
 import ir.syrent.velocityvanish.spigot.bridge.BukkitBridge
@@ -31,7 +28,6 @@ import ir.syrent.velocityvanish.spigot.utils.Utils
 import ir.syrent.velocityvanish.utils.component
 import org.bstats.bukkit.Metrics
 import org.bukkit.entity.Player
-import su.nightexpress.sunlight.api.event.PlayerTeleportRequestEvent
 
 
 class VelocityVanishSpigot : RUoMPlugin() {

--- a/src/main/java/ir/syrent/velocityvanish/spigot/core/VanishManager.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/core/VanishManager.kt
@@ -41,6 +41,8 @@ class VanishManager(
     private val plugin: VelocityVanishSpigot
 ) {
 
+    val flyingPlayers = mutableListOf<UUID>()
+
     private val potions = mutableSetOf(
         PotionEffect(PotionEffectType.NIGHT_VISION, Int.MAX_VALUE, 255, false, false),
         PotionEffect(PotionEffectType.FIRE_RESISTANCE, Int.MAX_VALUE, 255, false, false),
@@ -170,7 +172,11 @@ class VanishManager(
         updateTabState(player, GameMode.SPECTATOR)
         hidePlayer(player)
 
-        if (player.hasPermission("velocityvanish.action.fly.onvanish")) {
+        if (player.isFlying || player.allowFlight) {
+            flyingPlayers.add(player.uniqueId)
+        }
+
+        if (player.hasPermission("velocityvanish.action.fly.onvanish") || player.isOp || player.allowFlight) {
             player.allowFlight = true
             player.isFlying = true
         }
@@ -296,9 +302,10 @@ class VanishManager(
 
         updateTabState(player, GameMode.SURVIVAL)
 
-        val canFly = (player.allowFlight && player.hasPermission("velocityvanish.action.fly.onvanish")) || player.isOp
+        val canFly = player.isOp || player.gameMode == GameMode.CREATIVE || flyingPlayers.contains(player.uniqueId)
         player.allowFlight = canFly
         player.isFlying = canFly
+        flyingPlayers.remove(player.uniqueId)
 
         if (ServerVersion.supports(9)) {
             player.isInvulnerable = false /*invulnerablePlayers.contains(player.uniqueId)*/

--- a/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/DiscordSRVHook.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/DiscordSRVHook.kt
@@ -2,7 +2,6 @@ package ir.syrent.velocityvanish.spigot.hook.hooks
 
 import github.scarsz.discordsrv.DiscordSRV
 import ir.syrent.velocityvanish.spigot.hook.Dependency
-import ir.syrent.velocityvanish.spigot.ruom.Ruom
 
 class DiscordSRVHook(name: String) : Dependency(name) {
 

--- a/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/ProtocolLibHook.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/ProtocolLibHook.kt
@@ -3,7 +3,6 @@ package ir.syrent.velocityvanish.spigot.hook.hooks
 import com.comphenix.protocol.ProtocolLibrary
 import com.comphenix.protocol.ProtocolManager
 import ir.syrent.velocityvanish.spigot.hook.Dependency
-import ir.syrent.velocityvanish.spigot.ruom.Ruom
 
 class ProtocolLibHook(name: String) : Dependency(name) {
 

--- a/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/SquareMapHook.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/SquareMapHook.kt
@@ -1,7 +1,6 @@
 package ir.syrent.velocityvanish.spigot.hook.hooks
 
 import ir.syrent.velocityvanish.spigot.hook.Dependency
-import ir.syrent.velocityvanish.spigot.ruom.Ruom
 import xyz.jpenilla.squaremap.api.Squaremap
 import xyz.jpenilla.squaremap.api.SquaremapProvider
 

--- a/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/SunlightHook.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/hook/hooks/SunlightHook.kt
@@ -1,7 +1,6 @@
 package ir.syrent.velocityvanish.spigot.hook.hooks
 
 import ir.syrent.velocityvanish.spigot.hook.Dependency
-import ir.syrent.velocityvanish.spigot.ruom.Ruom
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import su.nightexpress.sunlight.SunLight

--- a/src/main/java/ir/syrent/velocityvanish/spigot/listener/PlayerJoinListener.kt
+++ b/src/main/java/ir/syrent/velocityvanish/spigot/listener/PlayerJoinListener.kt
@@ -1,9 +1,6 @@
 package ir.syrent.velocityvanish.spigot.listener
 
-import com.Zrips.CMI.CMI
-import com.Zrips.CMI.commands.list.vanishedit
 import ir.syrent.velocityvanish.spigot.VelocityVanishSpigot
-import ir.syrent.velocityvanish.spigot.hook.DependencyManager
 import ir.syrent.velocityvanish.spigot.ruom.Ruom
 import ir.syrent.velocityvanish.spigot.storage.Message
 import ir.syrent.velocityvanish.spigot.storage.Settings
@@ -35,7 +32,12 @@ class PlayerJoinListener(
     }
 
     fun handleVanishOnJoin(event: PlayerJoinEvent) {
-        val player = event.player
+        val oldPlayer = event.player
+        /*
+        * Velocity plugin message problem on 1.20.2 (1.20.2 is not yet supported offically)
+        * https://github.com/PaperMC/Velocity/pull/1088#issuecomment-1744385241
+        * */
+        val player = Bukkit.getPlayer(oldPlayer.uniqueId) ?: return
 
         // Note: DiscordSRV support
         player.setMetadata("vanished", FixedMetadataValue(plugin, true))


### PR DESCRIPTION
The new system now allows players to fly when they vanish if they meet one of the following conditions: they had access to flying before vanishing, they have operator permission, or they possess the fly-on-vanish permission. Conversely, it disables flying when they unvanish if they lack the necessary permissions or hadn't been flying previously.