### PR TITLE
feat: add configurable server list for ping updates

### DIFF
--- a/sayanvanish-proxy/sayanvanish-proxy-velocity/src/main/kotlin/org/sayandev/sayanvanish/velocity/feature/features/FeatureUpdatePing.kt
+++ b/sayanvanish-proxy/sayanvanish-proxy-velocity/src/main/kotlin/org/sayandev/sayanvanish/velocity/feature/features/FeatureUpdatePing.kt
@@ -3,15 +3,20 @@ package org.sayandev.sayanvanish.velocity.feature.features
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.proxy.ProxyPingEvent
 import com.velocitypowered.api.proxy.server.ServerPing
+import org.sayandev.sayanvanish.api.feature.Configurable
 import org.sayandev.sayanvanish.api.feature.RegisteredFeature
 import org.sayandev.sayanvanish.velocity.api.SayanVanishVelocityAPI
 import org.sayandev.sayanvanish.velocity.feature.ListenedFeature
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Comment
 import kotlin.jvm.optionals.getOrNull
 
 @RegisteredFeature
 @ConfigSerializable
-class FeatureUpdatePing : ListenedFeature("update_ping") {
+class FeatureUpdatePing(
+    @Comment("List of server names to update the ping for. if empty, the ping will be updated for all servers.")
+    @Configurable val servers: List<String> = emptyList()
+) : ListenedFeature("update_ping") {
 
     @Subscribe
     fun onProxyPing(event: ProxyPingEvent) {
@@ -25,9 +30,17 @@ class FeatureUpdatePing : ListenedFeature("update_ping") {
         val nonVanishedPlayersSample = pingPlayers.sample.filter { pingPlayer ->
             !vanishedOnlineUsersNames.contains(pingPlayer.name)
         }
+
+        var onlinePlayers = nonVanishedPlayersCount
+        if (!servers.isEmpty()) {
+            onlinePlayers = SayanVanishVelocityAPI.getInstance().database.getUsers().filter { user ->
+                !vanishedOnlineUsersNames.contains(user.username) && servers.contains(user.serverId)
+            }.size
+        }
+
         event.ping = event.ping
             .asBuilder()
-            .onlinePlayers(nonVanishedPlayersCount)
+            .onlinePlayers(onlinePlayers)
             .samplePlayers(*nonVanishedPlayersSample.map { ServerPing.SamplePlayer(it.name, it.id) }.toTypedArray())
             .build()
     }

--- a/sayanvanish-proxy/sayanvanish-proxy-velocity/src/main/kotlin/org/sayandev/sayanvanish/velocity/feature/features/FeatureUpdatePing.kt
+++ b/sayanvanish-proxy/sayanvanish-proxy-velocity/src/main/kotlin/org/sayandev/sayanvanish/velocity/feature/features/FeatureUpdatePing.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.optionals.getOrNull
 @RegisteredFeature
 @ConfigSerializable
 class FeatureUpdatePing(
-    @Comment("List of server names to update the ping for. if empty, the ping will be updated for all servers.")
+    @Comment("List of server names whose players are counted toward the online player count. If empty, players from all servers will be counted.")
     @Configurable val servers: List<String> = emptyList()
 ) : ListenedFeature("update_ping") {
 
@@ -22,25 +22,19 @@ class FeatureUpdatePing(
     fun onProxyPing(event: ProxyPingEvent) {
         if (!isActive()) return
         val pingPlayers = event.ping.players.getOrNull() ?: return
-        val vanishedOnlineUsers = SayanVanishVelocityAPI.getInstance().database.getUsers().filter { user -> user.isVanished && user.isOnline }
-        val vanishedOnlineUsersNames = vanishedOnlineUsers.map { vanishUser -> vanishUser.username }
+        val vanishedOnlineUsers = SayanVanishVelocityAPI.getInstance().database.getUsers().filter { user -> user.isVanished && user.isOnline && (servers.isEmpty() || user.serverId in servers) }
+        val vanishedOnlineUsersNames = vanishedOnlineUsers.map { vanishUser -> vanishUser.username }.toSet()
         val nonVanishedPlayersCount = SayanVanishVelocityAPI.getInstance().database.getBasicUsers(true).filter { basicUser ->
-            !vanishedOnlineUsersNames.contains(basicUser.username)
+            (servers.isEmpty() || basicUser.serverId in servers) &&
+                !vanishedOnlineUsersNames.contains(basicUser.username)
         }.size
         val nonVanishedPlayersSample = pingPlayers.sample.filter { pingPlayer ->
             !vanishedOnlineUsersNames.contains(pingPlayer.name)
         }
 
-        var onlinePlayers = nonVanishedPlayersCount
-        if (!servers.isEmpty()) {
-            onlinePlayers = SayanVanishVelocityAPI.getInstance().database.getUsers().filter { user ->
-                !vanishedOnlineUsersNames.contains(user.username) && servers.contains(user.serverId)
-            }.size
-        }
-
         event.ping = event.ping
             .asBuilder()
-            .onlinePlayers(onlinePlayers)
+            .onlinePlayers(nonVanishedPlayersCount)
             .samplePlayers(*nonVanishedPlayersSample.map { ServerPing.SamplePlayer(it.name, it.id) }.toTypedArray())
             .build()
     }


### PR DESCRIPTION
This PR makes the servers counted towards the online players in the server ping configurable. The main motivation for this change is to avoid conflicts with the SayanVanish plugin, which typically occur when trying to implement this feature via external MOTD plugins.